### PR TITLE
Setup maven dependency plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 target/
 *.out
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <description>The RelationalAI Software Development Kit (SDK) for Java</description>
     <groupId>com.relationalai</groupId>
     <artifactId>rai-sdk-pom</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.1</version>
     <packaging>pom</packaging>
     <url></url>
 

--- a/rai-sdk-examples/pom.xml
+++ b/rai-sdk-examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.relationalai</groupId>
         <artifactId>rai-sdk-pom</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.1</version>
     </parent>
 
     <name>RelationalAI SDK for Java Examples</name>

--- a/rai-sdk/pom.xml
+++ b/rai-sdk/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.relationalai</groupId>
         <artifactId>rai-sdk-pom</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.1</version>
     </parent>
 
     <name>RelationalAI SDK for Java Package</name>
@@ -67,5 +67,11 @@
                 <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 </project>

--- a/rai-sdk/src/main/resources/project.properties
+++ b/rai-sdk/src/main/resources/project.properties
@@ -1,0 +1,1 @@
+sdk.version=${project.version}


### PR DESCRIPTION
Configuring `maven-dependency-plugin` to generate child modules dependencies under `project/target/libs`.

I'm currently configuring SNB benchmark to use the java sdk I find this useful to run the SDK using java without requiring maven exec
```
java -cp ./rai-sdk-examples/target/*:./rai-sdk-examples/target/libs/* com.relationalai.examples.Runner CreateDatabase somedb someengine
```

Setup project.properties to get project version from pom.xml