### PR TITLE
Implement HttpError#getMessage.

### DIFF
--- a/rai-sdk/src/main/java/com/relationalai/HttpError.java
+++ b/rai-sdk/src/main/java/com/relationalai/HttpError.java
@@ -53,6 +53,10 @@ public class HttpError extends Exception {
         this.statusCode = statusCode;
         this.message = message;
     }
+    
+    public String getMessage() {
+        return this.message;
+    }
 
     public String toString() {
         String result = Integer.toString(statusCode);


### PR DESCRIPTION
This makes it easier to see the underlying error in IDE tooling. E.g., using from Clojure in Emacs.

Before:

![Screen Shot 2022-06-17 at 2 55 37 PM](https://user-images.githubusercontent.com/147919/174406301-810bd1b8-0b6a-48fe-966a-ea7e0e1e668e.png)

After:

![Screen Shot 2022-06-17 at 3 03 56 PM](https://user-images.githubusercontent.com/147919/174406736-31b78562-c2ae-43c2-9a66-7cab61025a0e.png)

