### PR TITLE
Bump version of slf4j to 1.7.25

### DIFF
--- a/rai-sdk/pom.xml
+++ b/rai-sdk/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.25</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I bumped the version of slf4j to 1.7.25, as one of our clients banned the user of earlier versions.