### PR TITLE
Moving test logic to github action for re-use

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -42,7 +42,7 @@ runs:
         CLIENT_SECRET: ${{ inputs.client_secret }}
         CLIENT_CREDENTIALS_URL: ${{ inputs.client_credentials_url }}
         HOST: ${{ inputs.rai_host }}
-        CUSTOM_HEADERS: ${{ inputs.cutom_headers }}
+        CUSTOM_HEADERS: ${{ inputs.custom_headers }}
       run: |
           export JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED"
           mkdir -p ~/.rai

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,50 @@
+name: 'rai-sdk-java test'
+
+inputs:
+  client_id:
+    required: true
+    description: 'Client ID for oAuth'
+
+  client_secret:
+    required: true
+    description: 'Client secret for oAuth'
+
+  client_credentials_url:
+    required: true
+    description: 'Client credentials url for fetching the oAuth token'
+
+  rai_host:
+    required: false
+    description: 'RAI host'
+    default: 'azure.relationalai.com'
+
+  custom_headers:
+    required: false
+    description: 'Optional http headers'
+    default: '{}'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: RelationalAI/rai-sdk-java
+
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java-version }}
+        distribution: 'adopt'
+
+    - name: Build and Test with Maven
+      env:
+        CLIENT_ID: ${{ inputs.client_id }}
+        CLIENT_SECRET: ${{ inputs.client_secret }}
+        CLIENT_CREDENTIALS_URL: ${{ inputs.client_credentials_url }}
+        HOST: ${{ inputs.rai_host }}
+        CUSTOM_HEADERS: ${{ inputs.cutom_headers }}
+      run: |
+          export JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED"
+          mkdir -p ~/.rai
+          mvn clean install
+      shell: bash

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -8,24 +8,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         java-version: [ 11, 17, 18 ]
       fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - uses: ./.github/actions/test
         with:
-          java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
-      - name: Build with Maven
-        env:
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-          CLIENT_CREDENTIALS_URL: ${{ secrets.CLIENT_CREDENTIALS_URL }}
+          client_id: ${{ secrets.CLIENT_ID }}
+          client_secret: ${{ secrets.CLIENT_SECRET }}
+          client_credentials_url: ${{ secrets.CLIENT_CREDENTIALS_URL }}
         run: |
           export JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED"
           mkdir -p ~/.rai

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -19,7 +19,3 @@ jobs:
           client_id: ${{ secrets.CLIENT_ID }}
           client_secret: ${{ secrets.CLIENT_SECRET }}
           client_credentials_url: ${{ secrets.CLIENT_CREDENTIALS_URL }}
-        run: |
-          export JAVA_TOOL_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED"
-          mkdir -p ~/.rai
-          mvn clean install

--- a/rai-sdk/src/test/java/com/relationalai/UnitTest.java
+++ b/rai-sdk/src/test/java/com/relationalai/UnitTest.java
@@ -35,7 +35,8 @@ public abstract class UnitTest {
         }
 
         var cfg = String.format(
-                "[default]\nregion=us-east\nport=443\nscheme=https\nclient_id=%s\nclient_secret=%s\nclient_credentials_url=%s",
+                "[default]\nhost=%s\nregion=us-east\nport=443\nscheme=https\nclient_id=%s\nclient_secret=%s\nclient_credentials_url=%s",
+                getenv("HOST"),
                 getenv("CLIENT_ID"),
                 getenv("CLIENT_SECRET"),
                 getenv("CLIENT_CREDENTIALS_URL")


### PR DESCRIPTION
Modularizing the test logic to a github composite action so that other repositories can use the same test logic from the CI workflows