### PR TITLE
Added the Java version param with a default value if the caller does not provide matrix.java-version

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -22,6 +22,11 @@ inputs:
     required: false
     description: 'Optional http headers'
     default: '{}'
+  
+  java_version:
+    required: false
+    description: 'Java version to test with'
+    default: '18'
 
 runs:
   using: 'composite'
@@ -35,7 +40,7 @@ runs:
       env:
         JAVA_VERSION: '1.8'
       with:
-        java-version: ${{ matrix.java-version || env.JAVA_VERSION }}
+        java-version: ${{ matrix.java-version || inputs.java_version }}
         distribution: 'adopt'
 
     - name: Build and Test with Maven

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -22,11 +22,6 @@ inputs:
     required: false
     description: 'Optional http headers'
     default: '{}'
-  
-  java_version:
-    required: false
-    description: 'Java version to test with'
-    default: '18'
 
 runs:
   using: 'composite'
@@ -37,8 +32,10 @@ runs:
 
     - name: Set up JDK
       uses: actions/setup-java@v3
+      env:
+        JAVA_VERSION: '1.8'
       with:
-        java-version: ${{ matrix.java-version || inputs.java_version }}
+        java-version: ${{ matrix.java-version || env.JAVA_VERSION }}
         distribution: 'adopt'
 
     - name: Build and Test with Maven

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 18
+        java-version: ${{ matrix.java-version }} || '1.8'
         distribution: 'adopt'
 
     - name: Build and Test with Maven

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: ${{ matrix.java-version }}
+        java-version: 18
         distribution: 'adopt'
 
     - name: Build and Test with Maven

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -22,6 +22,11 @@ inputs:
     required: false
     description: 'Optional http headers'
     default: '{}'
+  
+  java_version:
+    required: false
+    description: 'Java version to test with'
+    default: '18'
 
 runs:
   using: 'composite'
@@ -33,7 +38,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: ${{ matrix.java-version }} || '1.8'
+        java-version: ${{ matrix.java-version || inputs.java_version }}
         distribution: 'adopt'
 
     - name: Build and Test with Maven

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -8,6 +8,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 11, 17, 18 ]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/test

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -8,10 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java-version: [ 11, 17, 18 ]
-      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/test


### PR DESCRIPTION
Removing the matrix strategy from the test workflow and action. Using the latest version of Java. 
Context: https://relationalai.atlassian.net/browse/RAI-8163