### PR TITLE
load csv test should not cleanup engine resource

### DIFF
--- a/rai-sdk/src/test/java/com/relationalai/LoadCsvTest.java
+++ b/rai-sdk/src/test/java/com/relationalai/LoadCsvTest.java
@@ -266,11 +266,5 @@ public class LoadCsvTest extends UnitTest {
         var client = createClient();
         var deleteRsp = client.deleteDatabase(databaseName);
         assertEquals(databaseName, deleteRsp.name);
-        try {
-            // deleteEngineWait terminates its polling loop with a 404
-            client.deleteEngineWait(engineName);
-        } catch (HttpError e) {
-            assertEquals(e.statusCode, 404);
-        }
     }
 }


### PR DESCRIPTION
The load csv test is cleaning the engine after test completion which is not supposed to be the case.
Resources are cleaned up after all tests completion. This issue is intermittent and we don't see it often because it depends from the tests execution order.